### PR TITLE
Fix minor typo in LLVM practice and update LLVM version in HW4  

### DIFF
--- a/hw4.md
+++ b/hw4.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-llvmver: 3.8
+llvmver: 8.0.0
 img: caffeine
 img_link: "https://en.wikipedia.org/wiki/Decaffeination"
 caption: "The Swiss Water Method uses water and osmosis to decaffeinate coffee beans. Developed in Switzerland in 1933 and turned into a commercially viable method by Coffex S.A. in 1980, in 1988 it became a product sold by The Swiss Water Decaffeinated Coffee Company of Burnaby, British Columbia, Canada."

--- a/llvm-practice.md
+++ b/llvm-practice.md
@@ -94,8 +94,8 @@ question explains the use of the `getelementptr` to access global constants.
 The LLVM assembly file can be run directly using the `lli` command:
 
     llvmconfig=llvm-config-8
-    lli-bin=`$llvmconfig --bindir`/lli
-    $lli-bin helloworld.ll
+    lli_bin=`$llvmconfig --bindir`/lli
+    $lli_bin helloworld.ll
 
 In this case we did not need to link with the Decaf standard library
 since we do not use any of the functions in it, but when we implement


### PR DESCRIPTION
- Update bash variable naming by removing hyphen in LLVM practice
- Update LLVM version to `8.0.0` in HW4 